### PR TITLE
Fix/adding neoforge instance fails

### DIFF
--- a/src/instance/launch/mod.rs
+++ b/src/instance/launch/mod.rs
@@ -412,6 +412,7 @@ pub async fn build_launch_invocation(
     // so we check there first.
     let has_local_libs = matches!(config.loader, ModLoader::Forge | ModLoader::NeoForge);
     let local_lib_dir = minecraft_dir.join("libraries");
+    let library_directory = if has_local_libs { &local_lib_dir } else { &lib_dir };
 
     let mut classpath: Vec<PathBuf> = Vec::new();
     for lib in &merged_profile.libraries {
@@ -501,7 +502,7 @@ pub async fn build_launch_invocation(
         .join("natives");
     let version_type = merged_profile.type_.as_deref().unwrap_or("release");
     let template_ctx = TemplateContext {
-        library_directory: &lib_dir,
+        library_directory,
         classpath_separator: sep,
         version_name: &config.game_version,
         version_type,

--- a/src/instance/launch/mod.rs
+++ b/src/instance/launch/mod.rs
@@ -28,6 +28,22 @@ pub enum LaunchError {
     Json(#[from] serde_json::Error),
     #[error("{0} launch is not yet supported")]
     NotSupported(String),
+    #[error(
+        "This instance requires Java {required}, but rmcl is using Java {detected}: {java}"
+    )]
+    JavaTooOld {
+        java: String,
+        required: u32,
+        detected: u32,
+    },
+    #[error(
+        "This instance requires Java {required}, but rmcl could not check {java}: {reason}"
+    )]
+    JavaCheckFailed {
+        java: String,
+        required: u32,
+        reason: String,
+    },
     #[error("{0}")]
     Auth(String),
 }
@@ -40,6 +56,68 @@ fn build_game_args(
     let rendered = render::render_args(profile, rule_ctx, template_ctx)
         .map_err(|e| LaunchError::Parse(format!("Failed to render args: {e}")))?;
     Ok((rendered.jvm, rendered.game))
+}
+
+fn parse_java_major_version(text: &str) -> Option<u32> {
+    let quoted = text
+        .split_once('"')
+        .and_then(|(_, rest)| rest.split_once('"').map(|(version, _)| version));
+
+    let token = quoted.or_else(|| {
+        let start = text.find(|c: char| c.is_ascii_digit())?;
+        Some(&text[start..])
+    })?;
+
+    let parts: Vec<u32> = token
+        .split(|c: char| !c.is_ascii_digit())
+        .filter(|part| !part.is_empty())
+        .filter_map(|part| part.parse::<u32>().ok())
+        .collect();
+
+    match parts.as_slice() {
+        [1, legacy_major, ..] => Some(*legacy_major),
+        [major, ..] => Some(*major),
+        [] => None,
+    }
+}
+
+async fn check_java_version(java: &str, required: Option<u32>) -> Result<(), LaunchError> {
+    let Some(required) = required.filter(|major| *major > 0) else {
+        return Ok(());
+    };
+
+    let output = tokio::process::Command::new(java)
+        .arg("-version")
+        .output()
+        .await
+        .map_err(|e| LaunchError::JavaCheckFailed {
+            java: java.to_owned(),
+            required,
+            reason: e.to_string(),
+        })?;
+
+    let version_text = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let detected =
+        parse_java_major_version(&version_text).ok_or_else(|| LaunchError::JavaCheckFailed {
+            java: java.to_owned(),
+            required,
+            reason: format!("could not parse `java -version` output: {version_text:?}"),
+        })?;
+
+    if detected < required {
+        return Err(LaunchError::JavaTooOld {
+            java: java.to_owned(),
+            required,
+            detected,
+        });
+    }
+
+    Ok(())
 }
 
 // existing installs from rmcl <= 0.3.0 have meta.json files in the
@@ -407,6 +485,15 @@ pub async fn build_launch_invocation(
         })
         .unwrap_or_else(crate::net::detect_java_path);
 
+    check_java_version(
+        &java,
+        merged_profile
+            .java_version
+            .as_ref()
+            .map(|version| version.major_version),
+    )
+    .await?;
+
     let assets_root = meta_dir.join("assets");
     let natives_dir = meta_dir
         .join("versions")
@@ -760,6 +847,18 @@ fn emit_parsed_instance_log(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[rstest::rstest]
+    #[case("openjdk version \"25.0.3\" 2026-04-21", Some(25))]
+    #[case("openjdk version \"21.0.11\" 2026-04-21", Some(21))]
+    #[case("java version \"1.8.0_402\"", Some(8))]
+    #[case("garbage", None)]
+    fn parse_java_major_version_handles_common_outputs(
+        #[case] output: &str,
+        #[case] expected: Option<u32>,
+    ) {
+        assert_eq!(parse_java_major_version(output), expected);
+    }
 
     #[test]
     fn build_game_args_renders_upstream_arguments() {

--- a/src/instance/loader/fabric.rs
+++ b/src/instance/loader/fabric.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
-use super::{GameVersion, ModLoaderInstaller};
+use super::{GameVersion, InstallError, InstallerError, ModLoaderInstaller};
 use crate::instance::models::ModLoader;
 use crate::net::{HttpClient, NetError, fabric as fabric_api};
 
@@ -49,7 +49,7 @@ impl ModLoaderInstaller for FabricInstaller {
         loader_version: &str,
         _instance_dir: &Path,
         meta_dir: &Path,
-    ) -> Result<(), NetError> {
+    ) -> Result<(), InstallError> {
         tracing::info!(
             "Installing Fabric {} for Minecraft {}",
             loader_version,
@@ -67,7 +67,8 @@ impl ModLoaderInstaller for FabricInstaller {
             meta_dir,
             &format!("fabric-{game_version}-{loader_version}.json"),
             &raw_bytes,
-        )?;
+        )
+        .map_err(InstallerError::from)?;
         tracing::debug!(
             "Saved Fabric profile for Minecraft {} loader {}",
             game_version,

--- a/src/instance/loader/forge.rs
+++ b/src/instance/loader/forge.rs
@@ -70,7 +70,6 @@ impl ModLoaderInstaller for ForgeInstaller {
             .await
             {
                 let _ = tokio::fs::remove_file(&installer_jar).await;
-                tracing::error!("Legacy Forge installation failed: {}", e);
                 return Err(e);
             }
         } else {
@@ -85,7 +84,6 @@ impl ModLoaderInstaller for ForgeInstaller {
                 forge_api::run_forge_installer(&installer_jar, instance_dir, &java_path).await
             {
                 let _ = tokio::fs::remove_file(&installer_jar).await;
-                tracing::error!("Modern Forge installer failed: {}", e);
                 return Err(e);
             }
 

--- a/src/instance/loader/forge.rs
+++ b/src/instance/loader/forge.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
-use super::{GameVersion, ModLoaderInstaller};
+use super::{GameVersion, InstallError, ModLoaderInstaller};
 use crate::instance::models::ModLoader;
 use crate::net::{HttpClient, NetError, forge as forge_api};
 
@@ -44,7 +44,7 @@ impl ModLoaderInstaller for ForgeInstaller {
         loader_version: &str,
         instance_dir: &Path,
         meta_dir: &Path,
-    ) -> Result<(), NetError> {
+    ) -> Result<(), InstallError> {
         let installer_jar = instance_dir.join(".minecraft").join("forge-installer.jar");
         tracing::info!(
             "Installing Forge {} for Minecraft {}",
@@ -84,11 +84,12 @@ impl ModLoaderInstaller for ForgeInstaller {
                 forge_api::run_forge_installer(&installer_jar, instance_dir, &java_path).await
             {
                 let _ = tokio::fs::remove_file(&installer_jar).await;
-                return Err(e);
+                return Err(InstallError::Installer(e));
             }
 
             // extract the profile from what the installer just wrote to disk
-            save_forge_profile(instance_dir, meta_dir, game_version, loader_version)?;
+            save_forge_profile(instance_dir, meta_dir, game_version, loader_version)
+                .map_err(InstallError::Installer)?;
         }
 
         if let Err(e) = tokio::fs::remove_file(&installer_jar).await {
@@ -109,7 +110,7 @@ fn save_forge_profile(
     meta_dir: &Path,
     game_version: &str,
     loader_version: &str,
-) -> Result<(), NetError> {
+) -> Result<(), super::InstallerError> {
     let version_dir_name = format!("{game_version}-forge-{loader_version}");
     let profile_filename = format!("forge-{game_version}-{loader_version}.json");
     super::save_installer_profile(instance_dir, meta_dir, &version_dir_name, &profile_filename)

--- a/src/instance/loader/mod.rs
+++ b/src/instance/loader/mod.rs
@@ -12,9 +12,28 @@ mod vanilla;
 use std::path::Path;
 
 use async_trait::async_trait;
+use thiserror::Error;
 
 use crate::instance::models::ModLoader;
 use crate::net::{HttpClient, NetError};
+
+#[derive(Debug, Error)]
+pub enum InstallerError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Process failed: {0}")]
+    ProcessFailed(String),
+    #[error("Profile error: {0}")]
+    Profile(String),
+}
+
+#[derive(Debug, Error)]
+pub enum InstallError {
+    #[error("Download error: {0}")]
+    Download(#[from] NetError),
+    #[error("Installer error: {0}")]
+    Installer(#[from] InstallerError),
+}
 
 pub use vanilla::VanillaInstaller;
 
@@ -43,7 +62,7 @@ pub trait ModLoaderInstaller: Send + Sync {
         loader_version: &str,
         instance_dir: &Path,
         meta_dir: &Path,
-    ) -> Result<(), NetError>;
+    ) -> Result<(), InstallError>;
 }
 
 // writes raw profile JSON bytes to meta_dir/loader-profiles/<filename>.
@@ -71,7 +90,7 @@ pub(crate) fn save_installer_profile(
     meta_dir: &Path,
     version_dir_name: &str,
     profile_filename: &str,
-) -> Result<(), NetError> {
+) -> Result<(), InstallerError> {
     let ver_json_path = instance_dir
         .join(".minecraft")
         .join("versions")
@@ -79,11 +98,11 @@ pub(crate) fn save_installer_profile(
         .join(format!("{version_dir_name}.json"));
 
     if !ver_json_path.exists() {
-        tracing::error!(
+        tracing::debug!(
             "Installer profile JSON missing: {}",
             ver_json_path.display()
         );
-        return Err(NetError::Parse(format!(
+        return Err(InstallerError::Profile(format!(
             "Version JSON not found at {}",
             ver_json_path.display()
         )));

--- a/src/instance/loader/neoforge.rs
+++ b/src/instance/loader/neoforge.rs
@@ -62,7 +62,6 @@ impl ModLoaderInstaller for NeoForgeInstaller {
             neoforge_api::run_neoforge_installer(&installer_jar, instance_dir, &java_path).await
         {
             let _ = tokio::fs::remove_file(&installer_jar).await;
-            tracing::error!("NeoForge installer failed: {}", e);
             return Err(e);
         }
 

--- a/src/instance/loader/neoforge.rs
+++ b/src/instance/loader/neoforge.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
-use super::{GameVersion, ModLoaderInstaller};
+use super::{GameVersion, InstallError, ModLoaderInstaller};
 use crate::instance::models::ModLoader;
 use crate::net::{HttpClient, NetError, neoforge as neoforge_api};
 
@@ -43,7 +43,7 @@ impl ModLoaderInstaller for NeoForgeInstaller {
         loader_version: &str,
         instance_dir: &Path,
         meta_dir: &Path,
-    ) -> Result<(), NetError> {
+    ) -> Result<(), InstallError> {
         let installer_jar = instance_dir
             .join(".minecraft")
             .join("neoforge-installer.jar");
@@ -62,14 +62,15 @@ impl ModLoaderInstaller for NeoForgeInstaller {
             neoforge_api::run_neoforge_installer(&installer_jar, instance_dir, &java_path).await
         {
             let _ = tokio::fs::remove_file(&installer_jar).await;
-            return Err(e);
+            return Err(InstallError::Installer(e));
         }
 
         if let Err(e) = tokio::fs::remove_file(&installer_jar).await {
             tracing::warn!("Failed to remove NeoForge installer JAR: {}", e);
         }
 
-        save_neoforge_profile(instance_dir, meta_dir, loader_version)?;
+        save_neoforge_profile(instance_dir, meta_dir, loader_version)
+            .map_err(InstallError::Installer)?;
 
         tracing::debug!("Installed NeoForge {}", loader_version);
         Ok(())
@@ -80,7 +81,7 @@ fn save_neoforge_profile(
     instance_dir: &Path,
     meta_dir: &Path,
     loader_version: &str,
-) -> Result<(), NetError> {
+) -> Result<(), super::InstallerError> {
     let version_dir_name = format!("neoforge-{loader_version}");
     let profile_filename = format!("neoforge-{loader_version}.json");
     super::save_installer_profile(instance_dir, meta_dir, &version_dir_name, &profile_filename)

--- a/src/instance/loader/quilt.rs
+++ b/src/instance/loader/quilt.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
-use super::{GameVersion, ModLoaderInstaller};
+use super::{GameVersion, InstallError, InstallerError, ModLoaderInstaller};
 use crate::instance::models::ModLoader;
 use crate::net::{HttpClient, NetError, quilt as quilt_api};
 
@@ -49,7 +49,7 @@ impl ModLoaderInstaller for QuiltInstaller {
         loader_version: &str,
         _instance_dir: &Path,
         meta_dir: &Path,
-    ) -> Result<(), NetError> {
+    ) -> Result<(), InstallError> {
         tracing::info!(
             "Installing Quilt {} for Minecraft {}",
             loader_version,
@@ -67,7 +67,8 @@ impl ModLoaderInstaller for QuiltInstaller {
             meta_dir,
             &format!("quilt-{game_version}-{loader_version}.json"),
             &raw_bytes,
-        )?;
+        )
+        .map_err(InstallerError::from)?;
         tracing::debug!(
             "Saved Quilt profile for Minecraft {} loader {}",
             game_version,

--- a/src/instance/loader/vanilla.rs
+++ b/src/instance/loader/vanilla.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use async_trait::async_trait;
 
-use super::{GameVersion, ModLoaderInstaller};
+use super::{GameVersion, InstallError, ModLoaderInstaller};
 use crate::instance::models::ModLoader;
 use crate::net::{HttpClient, NetError, mojang};
 
@@ -45,7 +45,7 @@ impl ModLoaderInstaller for VanillaInstaller {
         _loader_version: &str,
         _instance_dir: &Path,
         _meta_dir: &Path,
-    ) -> Result<(), NetError> {
+    ) -> Result<(), InstallError> {
         Ok(())
     }
 }

--- a/src/instance/manager.rs
+++ b/src/instance/manager.rs
@@ -6,6 +6,8 @@ use std::path::PathBuf;
 use chrono::Utc;
 use thiserror::Error;
 
+use crate::instance::loader::InstallError;
+use crate::instance::loader::InstallerError;
 use crate::instance::models::{InstanceConfig, ModLoader};
 
 #[derive(Debug, Error)]
@@ -20,6 +22,8 @@ pub enum InstanceError {
     Json(#[from] serde_json::Error),
     #[error("Download error: {0}")]
     Download(#[from] crate::net::NetError),
+    #[error("Installer error: {0}")]
+    InstallerError(#[from] InstallerError),
     #[error("Invalid instance name: {0}")]
     InvalidName(String),
 }
@@ -247,7 +251,11 @@ impl InstanceManager {
                 instance_dir,
                 &self.meta_dir,
             )
-            .await?;
+            .await
+            .map_err(|e| match e {
+                InstallError::Download(net_error) => InstanceError::Download(net_error),
+                InstallError::Installer(installer_error) => InstanceError::InstallerError(installer_error),
+            })?;
 
         let config = InstanceConfig {
             name: name.to_string(),

--- a/src/instance/manager.rs
+++ b/src/instance/manager.rs
@@ -92,8 +92,11 @@ impl InstanceManager {
             .await;
 
         // clean up on failure so there's no half-baked instance left around
-        if let Err(e) = &result {
-            tracing::error!("Instance '{}' creation failed: {}", name, e);
+        if result.is_err() {
+            tracing::debug!(
+                "Cleaning up incomplete instance '{}' after creation failed",
+                name
+            );
             if let Err(cleanup_error) = std::fs::remove_dir_all(&instance_dir) {
                 tracing::warn!(
                     "Failed to clean up incomplete instance directory {}: {}",
@@ -171,14 +174,10 @@ impl InstanceManager {
                 v
             }
             None => {
-                tracing::warn!(
+                return Err(InstanceError::InvalidName(format!(
                     "Minecraft version '{}' not found in manifest with {} entries",
                     game_version,
                     manifest.versions.len()
-                );
-                return Err(InstanceError::InvalidName(format!(
-                    "Minecraft version '{}' not found in manifest",
-                    game_version
                 )));
             }
         };
@@ -282,7 +281,14 @@ impl InstanceManager {
             return Err(InstanceError::NotFound(name.to_string()));
         }
         tracing::info!("Deleting instance '{}' at {}", name, instance_dir.display());
-        std::fs::remove_dir_all(&instance_dir)?;
+        if let Err(e) = std::fs::remove_dir_all(&instance_dir) {
+            tracing::error!(
+                "Failed to delete instance directory {}: {}",
+                instance_dir.display(),
+                e
+            );
+            return Err(e.into());
+        }
         if let Err(e) = crate::instance::desktop::remove(name) {
             tracing::warn!("Failed to remove desktop shortcut for '{}': {}", name, e);
         }
@@ -292,6 +298,7 @@ impl InstanceManager {
     pub fn rename(&self, old_name: &str, new_name: &str) -> Result<(), InstanceError> {
         let new_name = new_name.trim();
         if new_name.is_empty() {
+            tracing::warn!("Cannot rename instance '{}': new name is empty", old_name);
             return Err(InstanceError::InvalidName(
                 "Name cannot be empty".to_string(),
             ));
@@ -320,7 +327,15 @@ impl InstanceManager {
             return Err(InstanceError::AlreadyExists(new_name.to_string()));
         }
         tracing::info!("Renaming instance '{}' to '{}'", old_name, new_name);
-        std::fs::rename(&old_dir, &new_dir)?;
+        if let Err(e) = std::fs::rename(&old_dir, &new_dir) {
+            tracing::error!(
+                "Failed to rename instance directory {} to {}: {}",
+                old_dir.display(),
+                new_dir.display(),
+                e
+            );
+            return Err(e.into());
+        }
 
         let config_path = new_dir.join("instance.json");
         if let Ok(data) = std::fs::read_to_string(&config_path)
@@ -402,8 +417,30 @@ impl InstanceManager {
         }
 
         tracing::debug!("Loading instance '{}' from {}", name, config_path.display());
-        let contents = std::fs::read_to_string(&config_path)?;
-        Ok(serde_json::from_str::<InstanceConfig>(&contents)?)
+        let contents = match std::fs::read_to_string(&config_path) {
+            Ok(contents) => contents,
+            Err(e) => {
+                tracing::error!(
+                    "Failed to read instance '{}' config {}: {}",
+                    name,
+                    config_path.display(),
+                    e
+                );
+                return Err(e.into());
+            }
+        };
+        match serde_json::from_str::<InstanceConfig>(&contents) {
+            Ok(config) => Ok(config),
+            Err(e) => {
+                tracing::error!(
+                    "Failed to parse instance '{}' config {}: {}",
+                    name,
+                    config_path.display(),
+                    e
+                );
+                Err(e.into())
+            }
+        }
     }
 
     pub fn save(&self, instance: &InstanceConfig) -> Result<(), InstanceError> {

--- a/src/net/forge.rs
+++ b/src/net/forge.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use crate::instance::loader::GameVersion;
+use crate::instance::loader::{GameVersion, InstallError, InstallerError};
 use crate::net::{HttpClient, NetError, download_file};
 use crate::tui::progress::{set_action, set_sub_action};
 
@@ -141,7 +141,7 @@ pub async fn run_forge_installer(
     installer_path: &Path,
     instance_dir: &Path,
     java_path: &str,
-) -> Result<(), NetError> {
+) -> Result<(), InstallerError> {
     use tokio::process::Command;
 
     set_action("Running Forge installer...");
@@ -156,13 +156,13 @@ pub async fn run_forge_installer(
     {
         Ok(o) => o,
         Err(e) => {
-            tracing::error!(
+            tracing::debug!(
                 "Failed to spawn Forge installer {} with Java {}: {}",
                 installer_path.display(),
                 java_path,
                 e
             );
-            return Err(NetError::Io(e));
+            return Err(InstallerError::Io(e));
         }
     };
 
@@ -173,13 +173,13 @@ pub async fn run_forge_installer(
         } else {
             stderr.lines().last().unwrap_or("unknown error").to_string()
         };
-        tracing::error!(
+        tracing::debug!(
             "Forge installer {} failed with status {:?}: {}",
             installer_path.display(),
             output.status.code(),
             detail
         );
-        return Err(NetError::InstallerFailed(detail));
+        return Err(InstallerError::ProcessFailed(detail));
     }
 
     tracing::debug!("Forge installer completed successfully");
@@ -215,7 +215,7 @@ pub(crate) async fn install_forge_from_profile(
     installer_path: &Path,
     meta_dir: &Path,
     profile_filename: &str,
-) -> Result<(), NetError> {
+) -> Result<(), InstallError> {
     use std::io::Read;
 
     set_action("Installing legacy Forge from profile...");
@@ -225,63 +225,68 @@ pub(crate) async fn install_forge_from_profile(
         meta_dir.display()
     );
 
-    let file = std::fs::File::open(installer_path)?;
+    let file = std::fs::File::open(installer_path)
+        .map_err(|e| InstallError::Installer(InstallerError::Io(e)))?;
     let mut archive = zip::ZipArchive::new(file)
-        .map_err(|e| NetError::Parse(format!("Failed to open installer as ZIP: {e}")))?;
+        .map_err(|e| InstallError::Installer(InstallerError::Profile(format!("Failed to open installer as ZIP: {e}"))))?;
 
     let profile_data: serde_json::Value = {
         let entry = archive.by_name("install_profile.json").map_err(|e| {
-            NetError::Parse(format!("install_profile.json not found in installer: {e}"))
+            InstallError::Installer(InstallerError::Profile(format!("install_profile.json not found in installer: {e}")))
         })?;
         serde_json::from_reader(entry)
-            .map_err(|e| NetError::Parse(format!("Failed to parse install_profile.json: {e}")))?
+            .map_err(|e| InstallError::Installer(InstallerError::Profile(format!("Failed to parse install_profile.json: {e}"))))?
     };
 
     let version_info = profile_data
         .get("versionInfo")
-        .ok_or_else(|| NetError::Parse("install_profile.json missing versionInfo".into()))?;
+        .ok_or_else(|| InstallError::Installer(InstallerError::Profile("install_profile.json missing versionInfo".into())))?;
     let install_info = profile_data
         .get("install")
-        .ok_or_else(|| NetError::Parse("install_profile.json missing install section".into()))?;
+        .ok_or_else(|| InstallError::Installer(InstallerError::Profile("install_profile.json missing install section".into())))?;
 
     let libraries = version_info
         .get("libraries")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| NetError::Parse("missing versionInfo.libraries".into()))?;
+        .ok_or_else(|| InstallError::Installer(InstallerError::Profile("missing versionInfo.libraries".into())))?;
 
     let file_path = install_info
         .get("filePath")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| NetError::Parse("missing install.filePath".into()))?;
+        .ok_or_else(|| InstallError::Installer(InstallerError::Profile("missing install.filePath".into())))?;
 
     let install_path_coord = install_info
         .get("path")
         .and_then(|v| v.as_str())
-        .ok_or_else(|| NetError::Parse("missing install.path".into()))?;
+        .ok_or_else(|| InstallError::Installer(InstallerError::Profile("missing install.path".into())))?;
 
     // extract the universal jar to the correct maven location
     let universal_maven_path =
         crate::net::maven_coord_to_path(install_path_coord).ok_or_else(|| {
-            NetError::Parse(format!(
+            InstallError::Installer(InstallerError::Profile(format!(
                 "Invalid maven coord in install.path: {install_path_coord}"
-            ))
+            )))
         })?;
 
     set_sub_action("Extracting universal JAR...");
     let universal_dest = meta_dir.join("libraries").join(&universal_maven_path);
     if let Some(parent) = universal_dest.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent)
+            .map_err(|e| InstallError::Installer(InstallerError::Io(e)))?;
     }
 
     {
         let mut entry = archive.by_name(file_path).map_err(|e| {
-            NetError::Parse(format!(
+            InstallError::Installer(InstallerError::Profile(format!(
                 "Universal JAR '{file_path}' not found in installer: {e}"
-            ))
+            )))
         })?;
         let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
-        std::fs::write(&universal_dest, &buf)?;
+        entry
+            .read_to_end(&mut buf)
+            .map_err(|e| InstallError::Installer(InstallerError::Io(e)))?;
+        std::fs::write(&universal_dest, &buf)
+            .map_err(|e| InstallError::Installer(InstallerError::Io(e)))?;
         tracing::debug!(
             "Extracted legacy Forge universal JAR to {} ({} bytes)",
             universal_dest.display(),
@@ -295,12 +300,12 @@ pub(crate) async fn install_forge_from_profile(
     // in mojang's modern version metadata, so we fetch those too.
     let libraries_dir = meta_dir.join("libraries");
     for lib in libraries {
-        let name = lib.get("name").and_then(|v| v.as_str()).unwrap_or_default();
+            let name = lib.get("name").and_then(|v| v.as_str()).unwrap_or_default();
 
         let maven_path = match crate::net::maven_coord_to_path(name) {
             Some(p) => p,
             None => {
-                return Err(NetError::Parse(format!("Invalid Maven coordinate: {name}")));
+                return Err(InstallError::Installer(InstallerError::Profile(format!("Invalid Maven coordinate: {name}"))));
             }
         };
 
@@ -337,8 +342,9 @@ pub(crate) async fn install_forge_from_profile(
     // the source is a serde_json::Value (which doesn't preserve order),
     // but no field is silently dropped.
     let serialized = serde_json::to_vec(version_info)
-        .map_err(|e| NetError::Parse(format!("Failed to serialize Forge profile: {e}")))?;
-    crate::instance::loader::save_profile_bytes(meta_dir, profile_filename, &serialized)?;
+        .map_err(|e| InstallError::Installer(InstallerError::Profile(format!("Failed to serialize Forge profile: {e}"))))?;
+    crate::instance::loader::save_profile_bytes(meta_dir, profile_filename, &serialized)
+        .map_err(|e| InstallError::Installer(InstallerError::Io(e)))?;
     Ok(())
 }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -66,7 +66,7 @@ impl HttpClient {
         tracing::trace!("HTTP GET {}", url);
         let response = self.inner.get(url).send().await?;
         if !response.status().is_success() {
-            tracing::warn!(
+            tracing::debug!(
                 "HTTP GET {} returned non-success status {}",
                 url,
                 response.status()
@@ -119,41 +119,46 @@ where
     F: Fn(reqwest::Response) -> Fut,
     Fut: std::future::Future<Output = Result<T, NetError>>,
 {
-    let mut last_error = None;
     for attempt in 0..=MAX_RETRIES {
-        if attempt > 0 {
-            let delay = RETRY_BASE_DELAY_MS * 2u64.pow(attempt - 1);
-            tracing::warn!(
-                "retrying request after {}ms (attempt {}/{}): {}",
-                delay,
-                attempt + 1,
-                MAX_RETRIES + 1,
-                url
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
-        }
-
         match client.get(url).await {
             Ok(resp) => match decode(resp).await {
                 Ok(value) => return Ok(value),
                 Err(e) if is_retryable(&e) => {
-                    tracing::warn!("Retryable decode/request error for {}: {}", url, e);
-                    last_error = Some(e);
+                    if attempt == MAX_RETRIES {
+                        return Err(e);
+                    }
+                    sleep_before_retry("request", url, attempt, &e).await;
                 }
                 Err(e) => return Err(e),
             },
             Err(e) if is_retryable(&e) => {
-                tracing::warn!("Retryable request error for {}: {}", url, e);
-                last_error = Some(e);
+                if attempt == MAX_RETRIES {
+                    return Err(e);
+                }
+                sleep_before_retry("request", url, attempt, &e).await;
             }
             Err(e) => return Err(e),
         }
     }
-    Err(last_error.unwrap())
+    unreachable!("retry loop returns on success or final error")
 }
 
 const MAX_RETRIES: u32 = 3;
 const RETRY_BASE_DELAY_MS: u64 = 500;
+
+async fn sleep_before_retry(kind: &str, url: &str, attempt: u32, err: &NetError) {
+    let delay = RETRY_BASE_DELAY_MS * 2u64.pow(attempt);
+    tracing::warn!(
+        "{} failed, retrying after {}ms (attempt {}/{}): {}: {}",
+        kind,
+        delay,
+        attempt + 2,
+        MAX_RETRIES + 1,
+        url,
+        err
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+}
 
 // streams a file to disk in chunks, calling progress_cb(downloaded, total) along the way.
 // total will be 0 if the server doesn't send content-length, so callers
@@ -164,36 +169,25 @@ pub async fn download_file(
     dest: &Path,
     progress_cb: impl Fn(u64, u64),
 ) -> Result<(), NetError> {
-    let mut last_error = None;
     tracing::debug!("Downloading {} to {}", url, dest.display());
 
     for attempt in 0..=MAX_RETRIES {
-        if attempt > 0 {
-            let delay = RETRY_BASE_DELAY_MS * 2u64.pow(attempt - 1);
-            tracing::warn!(
-                "retrying download after {}ms (attempt {}/{}): {}",
-                delay,
-                attempt + 1,
-                MAX_RETRIES + 1,
-                url
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
-        }
-
         match download_file_once(client, url, dest, &progress_cb).await {
             Ok(()) => {
                 tracing::debug!("Downloaded {} to {}", url, dest.display());
                 return Ok(());
             }
             Err(e) if is_retryable(&e) => {
-                tracing::warn!("Retryable download error for {}: {}", url, e);
-                last_error = Some(e);
+                if attempt == MAX_RETRIES {
+                    return Err(e);
+                }
+                sleep_before_retry("download", url, attempt, &e).await;
             }
             Err(e) => return Err(e),
         }
     }
 
-    Err(last_error.unwrap())
+    unreachable!("retry loop returns on success or final error")
 }
 
 // single attempt at downloading a file to disk

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -23,8 +23,6 @@ pub enum NetError {
     Parse(String),
     #[error("Server returned error status {status}: {url}")]
     StatusError { status: u16, url: String },
-    #[error("Installer process failed: {0}")]
-    InstallerFailed(String),
     #[error("Task failed: {0}")]
     TaskFailed(String),
 }

--- a/src/net/mojang.rs
+++ b/src/net/mojang.rs
@@ -289,7 +289,7 @@ pub async fn download_assets_from(
                     match tokio::fs::create_dir_all(parent).await {
                         Ok(_) => {}
                         Err(e) => {
-                            tracing::error!("Failed to create asset index dir: {}", e);
+                            tracing::debug!("Failed to create asset index dir: {}", e);
                         }
                     }
                 }
@@ -298,7 +298,7 @@ pub async fn download_assets_from(
                         tracing::debug!("Saved asset index to {}", index_path.display());
                     }
                     Err(e) => {
-                        tracing::error!(
+                        tracing::debug!(
                             "Failed to write asset index {}: {}",
                             index_path.display(),
                             e
@@ -307,7 +307,7 @@ pub async fn download_assets_from(
                 }
             }
             Err(e) => {
-                tracing::error!("Failed to serialize asset index: {}", e);
+                tracing::debug!("Failed to serialize asset index: {}", e);
             }
         }
     }
@@ -394,13 +394,13 @@ async fn run_parallel_downloads(
                 set_sub_action(label);
             }
             Ok(Err(e)) => {
-                tracing::error!("Download failed: {}", e);
+                tracing::debug!("Download failed: {}", e);
                 if first_error.is_none() {
                     first_error = Some(e);
                 }
             }
             Err(e) => {
-                tracing::error!("Task panicked: {}", e);
+                tracing::debug!("Task panicked: {}", e);
                 if first_error.is_none() {
                     first_error = Some(NetError::TaskFailed(format!("Join error: {}", e)));
                 }

--- a/src/net/neoforge.rs
+++ b/src/net/neoforge.rs
@@ -20,8 +20,10 @@ struct NeoForgeMavenVersions {
     versions: Vec<String>,
 }
 
-// neoforge dropped the "1." from minecraft versions in their scheme,
-// so "1.20.4" becomes prefix "20.4." and "1.21" becomes "21.0."
+// neoforge historically dropped the "1." from minecraft versions in
+// their scheme, so "1.20.4" becomes prefix "20.4." and "1.21" becomes
+// "21.0.". newer minecraft versions such as "26.1.2" keep their full
+// version at the start of the neoforge coordinate: "26.1.2.76".
 fn game_version_to_neoforge_prefix(game_version: &str) -> Option<String> {
     let parts: Vec<&str> = game_version.split('.').collect();
     match parts.as_slice() {
@@ -29,8 +31,43 @@ fn game_version_to_neoforge_prefix(game_version: &str) -> Option<String> {
         ["1", minor] => Some(format!("{}.0.", minor)),
         // "1.20.4" → prefix "20.4."
         ["1", minor, patch] => Some(format!("{}.{}.", minor, patch)),
+        // "26.1.2" → prefix "26.1.2."
+        [major, minor, patch] if leading_u32(major).is_some_and(|major| major >= 26) => {
+            Some(format!("{major}.{minor}.{patch}."))
+        }
+        // "26.1" → prefix "26.1."
+        [major, minor] if leading_u32(major).is_some_and(|major| major >= 26) => {
+            Some(format!("{major}.{minor}."))
+        }
         _ => None,
     }
+}
+
+fn leading_u32(raw: &str) -> Option<u32> {
+    let digits: String = raw.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+fn neoforge_version_to_game_version(version: &str) -> Option<String> {
+    let parts: Vec<&str> = version.split('.').collect();
+    let major = leading_u32(parts.first()?)?;
+
+    if major >= 26 {
+        let minor = leading_u32(parts.get(1)?)?;
+        let patch = leading_u32(parts.get(2)?)?;
+        return Some(format!("{major}.{minor}.{patch}"));
+    }
+
+    let minor = leading_u32(parts.get(1)?)?;
+    Some(if minor == 0 {
+        format!("1.{major}")
+    } else {
+        format!("1.{major}.{minor}")
+    })
 }
 
 pub async fn fetch_neoforge_versions(
@@ -89,19 +126,10 @@ pub async fn fetch_neoforge_game_versions_from(
 
     let mut game_versions: Vec<String> = Vec::new();
     for version in &maven.versions {
-        let parts: Vec<&str> = version.split('.').collect();
-        if parts.len() >= 2
-            && let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>())
+        if let Some(mc_version) = neoforge_version_to_game_version(version)
+            && !game_versions.contains(&mc_version)
         {
-            let mc_version = if minor == 0 {
-                format!("1.{}", major)
-            } else {
-                format!("1.{}.{}", major, minor)
-            };
-
-            if !game_versions.contains(&mc_version) {
-                game_versions.push(mc_version);
-            }
+            game_versions.push(mc_version);
         }
     }
     game_versions.reverse();
@@ -233,6 +261,10 @@ mod tests {
         assert_eq!(
             game_version_to_neoforge_prefix("1.21.1"),
             Some("21.1.".to_string())
+        );
+        assert_eq!(
+            game_version_to_neoforge_prefix("26.1.2"),
+            Some("26.1.2.".to_string())
         );
         assert_eq!(game_version_to_neoforge_prefix("invalid"), None);
     }

--- a/src/net/neoforge.rs
+++ b/src/net/neoforge.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use serde::Deserialize;
 
 use crate::instance::loader::GameVersion;
+use crate::instance::loader::InstallerError;
 use crate::net::{HttpClient, NetError, download_file};
 use crate::tui::progress::set_action;
 
@@ -171,7 +172,7 @@ pub async fn run_neoforge_installer(
     installer_path: &Path,
     instance_dir: &Path,
     java_path: &str,
-) -> Result<(), NetError> {
+) -> Result<(), InstallerError> {
     use tokio::process::Command;
 
     set_action("Running NeoForge installer...");
@@ -186,26 +187,26 @@ pub async fn run_neoforge_installer(
     {
         Ok(o) => o,
         Err(e) => {
-            tracing::error!(
+            tracing::debug!(
                 "Failed to spawn NeoForge installer {} with Java {}: {}",
                 installer_path.display(),
                 java_path,
                 e
             );
-            return Err(NetError::Io(e));
+            return Err(InstallerError::Io(e));
         }
     };
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         let detail = stderr.lines().last().unwrap_or("").trim();
-        tracing::error!(
+        tracing::debug!(
             "NeoForge installer {} failed with status {:?}: {}",
             installer_path.display(),
             output.status.code(),
             detail
         );
-        return Err(NetError::InstallerFailed(format!(
+        return Err(InstallerError::ProcessFailed(format!(
             "NeoForge installer exited with {:?}",
             output.status.code()
         )));

--- a/src/net/neoforge.rs
+++ b/src/net/neoforge.rs
@@ -178,6 +178,7 @@ pub async fn run_neoforge_installer(
     set_action("Running NeoForge installer...");
 
     let output = match Command::new(java_path)
+        .arg(format!("-Duser.home={}", instance_dir.display()))
         .arg("-jar")
         .arg(installer_path)
         .arg("--installClient")

--- a/src/tui/event.rs
+++ b/src/tui/event.rs
@@ -254,7 +254,6 @@ impl App {
         let instance = match self.instance_manager.load_one(&instance.name) {
             Ok(config) => config,
             Err(e) => {
-                tracing::error!("Failed to load instance '{}': {}", instance.name, e);
                 error_buffer::push_error(error_buffer::ErrorEvent {
                     id: 0,
                     level: tracing::Level::ERROR,

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -71,14 +71,10 @@ impl App {
             match key_event.code {
                 KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
                     let name = confirm_popup::pending_delete_name();
-                    if !name.is_empty() {
-                        match self.instance_manager.delete(&name) {
-                            Ok(_) => {
-                                self.instances_state.remove_instance(&name);
-                            }
-                            Err(_) => {}
+                    if !name.is_empty()
+                        && let Ok(_) = self.instance_manager.delete(&name) {
+                            self.instances_state.remove_instance(&name);
                         }
-                    }
                     confirm_popup::clear_pending();
                     self.focused = FocusedArea::Instances;
                     return Ok(());
@@ -190,19 +186,15 @@ impl App {
                             let new_name = self.instances_state.renaming.take().unwrap_or_default();
                             if let Some(inst) = self.instances_state.selected_instance() {
                                 let old_name = inst.name.clone();
-                                match self.instance_manager.rename(&old_name, &new_name) {
-                                    Ok(()) => {
-                                        if let Some(inst) = self
-                                            .instances_state
-                                            .instances
-                                            .iter_mut()
-                                            .find(|i| i.name == old_name)
-                                        {
-                                            inst.name = new_name.trim().to_owned();
-                                        }
+                                if let Ok(()) = self.instance_manager.rename(&old_name, &new_name)
+                                    && let Some(inst) = self
+                                        .instances_state
+                                        .instances
+                                        .iter_mut()
+                                        .find(|i| i.name == old_name)
+                                    {
+                                        inst.name = new_name.trim().to_owned();
                                     }
-                                    Err(_) => {}
-                                }
                             }
                         }
                         KeyCode::Esc => {

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -76,9 +76,7 @@ impl App {
                             Ok(_) => {
                                 self.instances_state.remove_instance(&name);
                             }
-                            Err(e) => {
-                                tracing::error!("Failed to delete instance '{}': {}", name, e);
-                            }
+                            Err(_) => {}
                         }
                     }
                     confirm_popup::clear_pending();
@@ -203,9 +201,7 @@ impl App {
                                             inst.name = new_name.trim().to_owned();
                                         }
                                     }
-                                    Err(e) => {
-                                        tracing::error!("Rename failed: {}", e);
-                                    }
+                                    Err(_) => {}
                                 }
                             }
                         }

--- a/tests/launch_pipeline.rs
+++ b/tests/launch_pipeline.rs
@@ -55,6 +55,22 @@ fn make_config_with(
     }
 }
 
+#[cfg(unix)]
+fn fake_java(tmp: &TempDir, major: u32) -> String {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = tmp.path().join(format!("java-{major}"));
+    std::fs::write(
+        &path,
+        format!("#!/bin/sh\necho 'openjdk version \"{major}.0.1\"' >&2\n"),
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&path, permissions).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
 // builds the on-disk layout that build_launch_invocation expects:
 //   <tmp>/instances/<name>/.minecraft/        (instance dir, created empty)
 //   <tmp>/meta/versions/<game_version>/meta.json
@@ -148,6 +164,15 @@ fn modern_vanilla_meta(id: &str) -> serde_json::Value {
     })
 }
 
+fn modern_vanilla_meta_with_java(id: &str, java_major: u32) -> serde_json::Value {
+    let mut meta = modern_vanilla_meta(id);
+    meta["javaVersion"] = json!({
+        "component": format!("java-runtime-{java_major}"),
+        "majorVersion": java_major
+    });
+    meta
+}
+
 fn legacy_vanilla_meta(id: &str) -> serde_json::Value {
     json!({
         "id": id,
@@ -182,14 +207,11 @@ async fn vanilla_modern_builds_complete_invocation() {
     assert_eq!(inv.main_class, "net.minecraft.client.main.Main");
     assert!(inv.extra_args.is_empty());
 
-    let expected_natives = fx
-        .meta_dir
-        .join("versions")
-        .join("1.20.1")
-        .join("natives");
+    let expected_natives = fx.meta_dir.join("versions").join("1.20.1").join("natives");
     assert!(
-        inv.jvm_args.iter().any(|a| a
-            == &format!("-Djava.library.path={}", expected_natives.display())),
+        inv.jvm_args
+            .iter()
+            .any(|a| a == &format!("-Djava.library.path={}", expected_natives.display())),
         "jvm_args missing natives substitution: {:?}",
         inv.jvm_args
     );
@@ -213,6 +235,34 @@ async fn vanilla_modern_builds_complete_invocation() {
     let client_jar = fx.meta_dir.join("versions/1.20.1/1.20.1.jar");
     assert!(inv.classpath.contains(&slf4j));
     assert!(inv.classpath.contains(&client_jar));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn launch_fails_when_selected_java_is_older_than_profile_requires() {
+    let fx = Fixture::new(
+        "java-old",
+        "26.1.2",
+        modern_vanilla_meta_with_java("26.1.2", 25),
+    );
+    let mut config = make_config("java-old", "26.1.2", ModLoader::Vanilla);
+    config.java_path = Some(fake_java(&fx._tmp, 21));
+
+    let err = build_launch_invocation(&config, &fx.instances_dir, &fx.meta_dir, &test_auth())
+        .await
+        .expect_err("java 21 should fail for a Java 25 profile");
+
+    assert!(
+        matches!(
+            err,
+            LaunchError::JavaTooOld {
+                required: 25,
+                detected: 21,
+                ..
+            }
+        ),
+        "expected JavaTooOld, got {err:?}"
+    );
 }
 
 #[tokio::test]
@@ -270,7 +320,10 @@ async fn forge_modern_includes_add_opens() {
         .await
         .unwrap();
 
-    assert_eq!(inv.main_class, "cpw.mods.bootstraplauncher.BootstrapLauncher");
+    assert_eq!(
+        inv.main_class,
+        "cpw.mods.bootstraplauncher.BootstrapLauncher"
+    );
     assert!(
         inv.jvm_args.iter().any(|a| a == "--add-opens"),
         "Forge --add-opens missing: {:?}",
@@ -311,9 +364,9 @@ async fn forge_local_lib_dir_preferred_over_meta_dir() {
 
     // drop fmlloader into the instance-local libraries dir so the launcher
     // finds it there rather than under the shared meta cache.
-    let local_lib =
-        fx.instance_libraries_dir("f2")
-            .join("net/minecraftforge/fmlloader/1.20.1-47.2.0");
+    let local_lib = fx
+        .instance_libraries_dir("f2")
+        .join("net/minecraftforge/fmlloader/1.20.1-47.2.0");
     std::fs::create_dir_all(&local_lib).unwrap();
     let local_jar = local_lib.join("fmlloader-1.20.1-47.2.0.jar");
     std::fs::write(&local_jar, b"jar").unwrap();
@@ -412,7 +465,10 @@ async fn neoforge_inheritsfrom_resolves() {
         .await
         .unwrap();
 
-    assert_eq!(inv.main_class, "cpw.mods.bootstraplauncher.BootstrapLauncher");
+    assert_eq!(
+        inv.main_class,
+        "cpw.mods.bootstraplauncher.BootstrapLauncher"
+    );
     assert!(
         inv.jvm_args
             .windows(2)
@@ -527,9 +583,7 @@ async fn rule_disallow_excludes_library() {
         .await
         .unwrap();
 
-    let denied = fx
-        .meta_dir
-        .join("libraries/com/denied/lib/1.0/lib-1.0.jar");
+    let denied = fx.meta_dir.join("libraries/com/denied/lib/1.0/lib-1.0.jar");
     assert!(
         !inv.classpath.contains(&denied),
         "denied library was included: {:?}",
@@ -680,4 +734,3 @@ async fn legacy_loader_profile_missing_installer_json_errors() {
         "expected Parse error about missing installer JSON, got: {err:?}"
     );
 }
-

--- a/tests/launch_pipeline.rs
+++ b/tests/launch_pipeline.rs
@@ -164,6 +164,7 @@ fn modern_vanilla_meta(id: &str) -> serde_json::Value {
     })
 }
 
+#[cfg(unix)]
 fn modern_vanilla_meta_with_java(id: &str, java_major: u32) -> serde_json::Value {
     let mut meta = modern_vanilla_meta(id);
     meta["javaVersion"] = json!({

--- a/tests/net_loaders.rs
+++ b/tests/net_loaders.rs
@@ -130,13 +130,15 @@ async fn fabric_fetch_profile_parses_libraries() {
         .mount(&server)
         .await;
 
-    let profile =
-        fetch_fabric_profile_from(&HttpClient::new(), &server.uri(), "1.20.1", "0.15.0")
-            .await
-            .expect("fabric profile");
+    let profile = fetch_fabric_profile_from(&HttpClient::new(), &server.uri(), "1.20.1", "0.15.0")
+        .await
+        .expect("fabric profile");
 
     assert_eq!(profile.id, "fabric-loader-0.15.0-1.20.1");
-    assert_eq!(profile.main_class, "net.fabricmc.loader.impl.launch.knot.KnotClient");
+    assert_eq!(
+        profile.main_class,
+        "net.fabricmc.loader.impl.launch.knot.KnotClient"
+    );
     assert_eq!(profile.libraries.len(), 1);
     assert_eq!(profile.libraries[0].url, "https://maven.fabricmc.net/");
 }
@@ -192,13 +194,15 @@ async fn quilt_fetch_profile_parses_libraries() {
         .mount(&server)
         .await;
 
-    let profile =
-        fetch_quilt_profile_from(&HttpClient::new(), &server.uri(), "1.20.1", "0.23.0")
-            .await
-            .expect("quilt profile");
+    let profile = fetch_quilt_profile_from(&HttpClient::new(), &server.uri(), "1.20.1", "0.23.0")
+        .await
+        .expect("quilt profile");
 
     assert_eq!(profile.id, "quilt-loader-0.23.0-1.20.1");
-    assert_eq!(profile.libraries[0].url, "https://maven.quiltmc.org/repository/release/");
+    assert_eq!(
+        profile.libraries[0].url,
+        "https://maven.quiltmc.org/repository/release/"
+    );
 }
 
 // ---------- neoforge ----------
@@ -230,6 +234,30 @@ async fn neoforge_fetch_versions_filters_by_prefix() {
 }
 
 #[tokio::test]
+async fn neoforge_fetch_versions_supports_modern_minecraft_numbering() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/maven-api"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "versions": [
+                "26.1.2.76",
+                "26.1.2.75",
+                "26.1.1.15",
+                "21.1.233"
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/maven-api", server.uri());
+    let versions = fetch_neoforge_versions_from(&HttpClient::new(), &url, "26.1.2")
+        .await
+        .expect("neoforge versions");
+
+    assert_eq!(versions, vec!["26.1.2.76", "26.1.2.75"]);
+}
+
+#[tokio::test]
 async fn neoforge_fetch_game_versions_reverse_engineers_mc_versions() {
     // neoforge "21.0.x" maps back to MC 1.21 (minor=0 strips the suffix);
     // "20.4.x" maps to MC 1.20.4. beta/alpha suffixes don't affect the
@@ -239,6 +267,8 @@ async fn neoforge_fetch_game_versions_reverse_engineers_mc_versions() {
         .and(path("/maven-api"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "versions": [
+                "26.1.2.76",
+                "26.1.1.15",
                 "21.0.10",
                 "21.0.5",
                 "20.4.190",
@@ -255,6 +285,8 @@ async fn neoforge_fetch_game_versions_reverse_engineers_mc_versions() {
     let ids: Vec<&str> = versions.iter().map(|v| v.id.as_str()).collect();
     // dedup keeps the first occurrence, output is reversed, so the
     // resulting list is in upstream maven-version order, deduped.
+    assert!(ids.contains(&"26.1.2"));
+    assert!(ids.contains(&"26.1.1"));
     assert!(ids.contains(&"1.21"));
     assert!(ids.contains(&"1.20.4"));
     // both versions should be marked stable (no snapshot flag in maven)


### PR DESCRIPTION
Fix NeoForge installation and launch handling by separating download and installer errors, preventing duplicate installer toasts, setting `user.home` so the NeoForge installer installs into the instance directory, and using the instance libraries directory for Forge and NeoForge launch arguments so NeoForge can start correctly
