### PR TITLE
feat(tui): add delete actions for instance content

### DIFF
--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -70,49 +70,56 @@ impl App {
         if self.focused == FocusedArea::ConfirmDelete {
             match key_event.code {
                 KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    if let Some(target) = confirm_popup::pending_target() {
-                        match target {
-                            confirm_popup::ConfirmTarget::Instance { name } => {
-                                match self.instance_manager.delete(&name) {
-                                    Ok(_) => {
-                                        self.instances_state.remove_instance(&name);
-                                    }
-                                    Err(e) => {
-                                        tracing::error!(
-                                            "Failed to delete instance '{}': {}",
-                                            name,
-                                            e
-                                        );
-                                    }
+                    let focus_after = match confirm_popup::pending_target() {
+                        Some(confirm_popup::ConfirmTarget::Instance { name }) => {
+                            match self.instance_manager.delete(&name) {
+                                Ok(_) => {
+                                    self.instances_state.remove_instance(&name);
                                 }
-                                self.focused = FocusedArea::Instances;
-                            }
-                            confirm_popup::ConfirmTarget::ConfigProfile { profile } => {
-                                if let Err(e) = self.delete_config_profile(&profile) {
-                                    error_buffer::push_error(error_buffer::ErrorEvent {
-                                        id: 0,
-                                        level: tracing::Level::ERROR,
-                                        message: e.to_string(),
-                                        pushed_at: std::time::Instant::now(),
-                                    });
+                                Err(e) => {
+                                    tracing::error!("Failed to delete instance '{}': {}", name, e);
                                 }
-                                self.focused = FocusedArea::Settings;
                             }
+                            FocusedArea::Instances
                         }
-                    }
+                        Some(confirm_popup::ConfirmTarget::ConfigProfile { profile }) => {
+                            if let Err(e) = self.delete_config_profile(&profile) {
+                                error_buffer::push_error(error_buffer::ErrorEvent {
+                                    id: 0,
+                                    level: tracing::Level::ERROR,
+                                    message: e.to_string(),
+                                    pushed_at: std::time::Instant::now(),
+                                });
+                            }
+                            FocusedArea::Settings
+                        }
+                        Some(confirm_popup::ConfirmTarget::Content { name, path }) => {
+                            match delete_content_path(&path) {
+                                Ok(()) => {
+                                    self.remove_content_path_from_states(&path);
+                                }
+                                Err(e) => {
+                                    tracing::error!("Failed to delete content '{}': {}", name, e);
+                                }
+                            }
+                            FocusedArea::Content
+                        }
+                        None => FocusedArea::Instances,
+                    };
                     confirm_popup::clear_pending();
+                    self.focused = focus_after;
                     return Ok(());
                 }
                 KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
-                    if matches!(
-                        confirm_popup::pending_target(),
-                        Some(confirm_popup::ConfirmTarget::ConfigProfile { .. })
-                    ) {
-                        self.focused = FocusedArea::Settings;
-                    } else {
-                        self.focused = FocusedArea::Instances;
-                    }
+                    let focus_after = match confirm_popup::pending_target() {
+                        Some(confirm_popup::ConfirmTarget::Content { .. }) => FocusedArea::Content,
+                        Some(confirm_popup::ConfirmTarget::ConfigProfile { .. }) => {
+                            FocusedArea::Settings
+                        }
+                        _ => FocusedArea::Instances,
+                    };
                     confirm_popup::clear_pending();
+                    self.focused = focus_after;
                     return Ok(());
                 }
                 _ => {
@@ -122,17 +129,41 @@ impl App {
         }
 
         // content area delegates to whichever tab is active.
-        // worlds get handle_key_no_toggle because you can't "disable" a world like you can a mod
+        // worlds use the same list navigation without the toggle
         if self.focused == FocusedArea::Content {
             if self.content_tab == widgets::content::ContentTab::Logs {
+                if key_event.code == KeyCode::Char('d')
+                    && !self.logs_state.search.active
+                    && !self.logs_state.viewer_search.active
+                {
+                    if let Some(pending) = self.logs_state.pending_delete() {
+                        confirm_popup::set_pending_content_delete(pending.name, pending.path);
+                        self.focused = FocusedArea::ConfirmDelete;
+                    }
+                    return Ok(());
+                }
                 if widgets::logs_viewer::handle_key(&key_event, &mut self.logs_state) {
                     return Ok(());
                 }
             } else if self.content_tab == widgets::content::ContentTab::Screenshots {
+                if key_event.code == KeyCode::Char('d') && !self.screenshots_state.search.active {
+                    if let Some(pending) = self.screenshots_state.pending_delete() {
+                        confirm_popup::set_pending_content_delete(pending.name, pending.path);
+                        self.focused = FocusedArea::ConfirmDelete;
+                    }
+                    return Ok(());
+                }
                 if widgets::screenshots_grid::handle_key(&key_event, &mut self.screenshots_state) {
                     return Ok(());
                 }
             } else if self.content_tab == widgets::content::ContentTab::Worlds {
+                if key_event.code == KeyCode::Char('d') && !self.worlds_state.search.active {
+                    if let Some(pending) = self.worlds_state.pending_delete() {
+                        confirm_popup::set_pending_content_delete(pending.name, pending.path);
+                        self.focused = FocusedArea::ConfirmDelete;
+                    }
+                    return Ok(());
+                }
                 if widgets::content::list::handle_key_no_toggle(&key_event, &mut self.worlds_state)
                 {
                     return Ok(());
@@ -146,10 +177,17 @@ impl App {
                     widgets::content::ContentTab::Shaders => Some(&mut self.shaders_state),
                     _ => None,
                 };
-                if let Some(state) = state
-                    && widgets::content::list::handle_key(&key_event, state)
-                {
-                    return Ok(());
+                if let Some(state) = state {
+                    if key_event.code == KeyCode::Char('d') && !state.search.active {
+                        if let Some(pending) = state.pending_delete() {
+                            confirm_popup::set_pending_content_delete(pending.name, pending.path);
+                            self.focused = FocusedArea::ConfirmDelete;
+                        }
+                        return Ok(());
+                    }
+                    if widgets::content::list::handle_key(&key_event, state) {
+                        return Ok(());
+                    }
                 }
             }
         }
@@ -326,7 +364,7 @@ impl App {
                     {
                         if let Some(instance) = self.instances_state.selected_instance() {
                             let name = instance.name.clone();
-                            confirm_popup::set_pending_delete(&name);
+                            confirm_popup::set_pending_instance_delete(&name);
                             self.focused = FocusedArea::ConfirmDelete;
                         }
                     }
@@ -438,5 +476,23 @@ impl App {
             .profiles
             .retain(|candidate| candidate != profile);
         Ok(())
+    }
+
+    fn remove_content_path_from_states(&mut self, path: &std::path::Path) {
+        self.mods_state.remove_path(path);
+        self.resource_packs_state.remove_path(path);
+        self.shaders_state.remove_path(path);
+        self.worlds_state.remove_path(path);
+        self.screenshots_state.remove_path(path);
+        self.logs_state.remove_path(path);
+    }
+}
+
+fn delete_content_path(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_dir() => std::fs::remove_dir_all(path),
+        Ok(_) => std::fs::remove_file(path),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -82,6 +82,18 @@ impl App {
                             }
                             FocusedArea::Instances
                         }
+                        Some(confirm_popup::ConfirmTarget::Account { index, .. }) => {
+                            let count = self.account_state.store.accounts.len();
+                            self.account_state.store.remove(index);
+                            if count > 1 {
+                                self.account_state.list_state.selected = Some(index.min(
+                                    self.account_state.store.accounts.len().saturating_sub(1),
+                                ));
+                            } else {
+                                self.account_state.list_state.selected = None;
+                            }
+                            FocusedArea::Account
+                        }
                         Some(confirm_popup::ConfirmTarget::ConfigProfile { profile }) => {
                             if let Err(e) = self.delete_config_profile(&profile) {
                                 error_buffer::push_error(error_buffer::ErrorEvent {
@@ -113,6 +125,7 @@ impl App {
                 KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
                     let focus_after = match confirm_popup::pending_target() {
                         Some(confirm_popup::ConfirmTarget::Content { .. }) => FocusedArea::Content,
+                        Some(confirm_popup::ConfirmTarget::Account { .. }) => FocusedArea::Account,
                         Some(confirm_popup::ConfirmTarget::ConfigProfile { .. }) => {
                             FocusedArea::Settings
                         }
@@ -190,6 +203,19 @@ impl App {
                     }
                 }
             }
+        }
+
+        if self.focused == FocusedArea::Account
+            && let KeyCode::Char('d') = key_event.code
+            && let Some(index) = self.account_state.list_state.selected
+            && let Some(account) = self.account_state.store.accounts.get(index)
+        {
+            confirm_popup::set_pending(confirm_popup::ConfirmTarget::Account {
+                username: account.username.clone(),
+                index,
+            });
+            self.focused = FocusedArea::ConfirmDelete;
+            return Ok(());
         }
 
         if self.focused == FocusedArea::Account

--- a/src/tui/widgets/account.rs
+++ b/src/tui/widgets/account.rs
@@ -27,7 +27,6 @@ pub enum AddMode {
     ChooseType,
     OfflineNameInput(String),
     OfflineBlocked,
-    ConfirmDelete(usize),
     DeviceCodeWaiting {
         info: DeviceCodeInfo,
         pending: Arc<Mutex<Option<AuthResult>>>,
@@ -163,39 +162,11 @@ pub fn handle_key(key_event: &KeyEvent, state: &mut AccountState) -> bool {
             }
             _ => true,
         },
-        AddMode::ConfirmDelete(idx) => {
-            let idx = *idx;
-            match key_event.code {
-                KeyCode::Enter | KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    let count = state.store.accounts.len();
-                    state.store.remove(idx);
-                    if count > 1 {
-                        state.list_state.selected =
-                            Some(idx.min(state.store.accounts.len().saturating_sub(1)));
-                    } else {
-                        state.list_state.selected = None;
-                    }
-                    state.add_mode = AddMode::None;
-                    true
-                }
-                KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
-                    state.add_mode = AddMode::None;
-                    true
-                }
-                _ => true,
-            }
-        }
         AddMode::None => {
             let count = state.store.accounts.len();
             match key_event.code {
                 KeyCode::Char('a') => {
                     state.add_mode = AddMode::ChooseType;
-                    true
-                }
-                KeyCode::Char('d') => {
-                    if let Some(idx) = state.list_state.selected {
-                        state.add_mode = AddMode::ConfirmDelete(idx);
-                    }
                     true
                 }
                 KeyCode::Enter => {
@@ -276,7 +247,6 @@ pub fn render(frame: &mut Frame, area: Rect, focused: FocusedArea, state: &mut A
         AddMode::ChooseType => render_choose_popup(frame),
         AddMode::OfflineNameInput(name) => render_offline_popup(frame, name),
         AddMode::OfflineBlocked => render_offline_blocked_popup(frame),
-        AddMode::ConfirmDelete(idx) => render_confirm_delete(frame, state, *idx),
         AddMode::DeviceCodeWaiting { info, .. } => render_device_code_popup(frame, info),
         AddMode::None => {}
     }
@@ -493,24 +463,6 @@ fn render_offline_blocked_popup(frame: &mut Frame) {
         }),
     }
     .render(area, frame.buffer_mut());
-}
-
-fn render_confirm_delete(frame: &mut Frame, state: &AccountState, idx: usize) {
-    use super::popups::confirm::ConfirmPopup;
-    let username = state
-        .store
-        .accounts
-        .get(idx)
-        .map(|a| a.username.as_str())
-        .unwrap_or("?");
-
-    let body = "This will permanently remove this account";
-    let popup_w = (username.len() + 14).max(body.len() + 2).min(48) as u16 + 2;
-    let area = popup_area(frame, popup_w, 3);
-    frame.render_widget(
-        ConfirmPopup::new(format!(" Delete '{}' ", username), body),
-        area,
-    );
 }
 
 fn render_device_code_popup(frame: &mut Frame, info: &DeviceCodeInfo) {

--- a/src/tui/widgets/content/list.rs
+++ b/src/tui/widgets/content/list.rs
@@ -56,6 +56,12 @@ pub struct ContentListState {
     content_ext: Option<&'static str>,
 }
 
+#[derive(Clone, Debug)]
+pub struct PendingContentDelete {
+    pub name: String,
+    pub path: std::path::PathBuf,
+}
+
 impl Default for ContentListState {
     fn default() -> Self {
         Self {
@@ -322,6 +328,16 @@ impl ContentListState {
             .map(|(i, _)| i)
             .collect()
     }
+
+    pub fn pending_delete(&self) -> Option<PendingContentDelete> {
+        let filtered = self.filtered_indices();
+        let real_idx = self.list_state.selected.and_then(|i| filtered.get(i))?;
+        let entry = self.entries.get(*real_idx)?;
+        Some(PendingContentDelete {
+            name: entry.name.clone(),
+            path: entry.path.clone(),
+        })
+    }
 }
 
 impl ContentListState {
@@ -486,6 +502,19 @@ impl ContentListState {
                 );
             }
         }
+    }
+
+    pub fn remove_path(&mut self, path: &Path) {
+        self.entries.retain(|entry| entry.path != path);
+        if let Some(sel) = self.list_state.selected {
+            let visible_count = self.filtered_indices().len();
+            if visible_count == 0 {
+                self.list_state.selected = None;
+            } else {
+                self.list_state.selected = Some(sel.min(visible_count.saturating_sub(1)));
+            }
+        }
+        self.update_scrollbar();
     }
 }
 

--- a/src/tui/widgets/content/tabs.rs
+++ b/src/tui/widgets/content/tabs.rs
@@ -148,12 +148,14 @@ pub fn render(
             ContentTab::Mods | ContentTab::ResourcePacks | ContentTab::Shaders => &[
                 ("j/k", " navigate"),
                 ("⏎", " toggle"),
+                ("d", " delete"),
                 ("Shift+⏎", " open dir"),
                 ("h/l", " tabs"),
                 ("/", " search"),
             ],
             ContentTab::Worlds => &[
                 ("j/k", " navigate"),
+                ("d", " delete"),
                 ("Shift+⏎", " open dir"),
                 ("h/l", " tabs"),
                 ("/", " search"),
@@ -161,6 +163,7 @@ pub fn render(
             ContentTab::Screenshots => &[
                 ("Shift+HJKL", " grid"),
                 ("⏎", " open"),
+                ("d", " delete"),
                 ("Shift+⏎", " open dir"),
                 ("h/l", " tabs"),
                 ("/", " search"),
@@ -170,6 +173,7 @@ pub fn render(
                     &[
                         ("j/k", " scroll"),
                         ("g/G", " top/bottom"),
+                        ("d", " delete"),
                         ("Esc", " back"),
                         ("/", " search"),
                     ]
@@ -177,6 +181,7 @@ pub fn render(
                     &[
                         ("j/k", " navigate"),
                         ("⏎", " view"),
+                        ("d", " delete"),
                         ("h/l", " tabs"),
                         ("/", " search"),
                     ]

--- a/src/tui/widgets/logs_viewer.rs
+++ b/src/tui/widgets/logs_viewer.rs
@@ -228,6 +228,33 @@ impl LogsState {
         self.viewer_scrollbar_state =
             ScrollbarState::new(self.viewer_max_scroll).position(self.viewer_scroll);
     }
+
+    pub fn pending_delete(
+        &self,
+    ) -> Option<crate::tui::widgets::content::list::PendingContentDelete> {
+        let index = self.file_index_for_selected()?;
+        let entry = self.entries.get(index)?;
+        Some(crate::tui::widgets::content::list::PendingContentDelete {
+            name: entry.name.clone(),
+            path: entry.path.clone(),
+        })
+    }
+
+    pub fn remove_path(&mut self, path: &Path) {
+        self.entries.retain(|entry| entry.path != path);
+        let display_count = self.display_count();
+        if display_count == 0 {
+            self.list_state.selected = None;
+            self.viewer_focused = false;
+            self.selected_path = None;
+            self.viewer_lines.clear();
+            self.viewer_scroll = 0;
+        } else if let Some(sel) = self.list_state.selected {
+            self.list_state.selected = Some(sel.min(display_count.saturating_sub(1)));
+            self.load_selected_content();
+        }
+        self.update_scrollbar();
+    }
 }
 
 pub fn handle_key(key_event: &KeyEvent, state: &mut LogsState) -> bool {

--- a/src/tui/widgets/popups/confirm.rs
+++ b/src/tui/widgets/popups/confirm.rs
@@ -1,4 +1,4 @@
-// "are you sure?" popup for instance deletion. uses global state so the
+// "are you sure?" popup for destructive actions. uses global state so the
 // confirmation target persists across render frames.
 
 use std::sync::LazyLock;
@@ -24,16 +24,21 @@ struct ConfirmState {
 
 #[derive(Debug, Clone)]
 pub enum ConfirmTarget {
-    Instance { name: String },
-    ConfigProfile { profile: String },
+    Instance {
+        name: String,
+    },
+    ConfigProfile {
+        profile: String,
+    },
+    Content {
+        name: String,
+        path: std::path::PathBuf,
+    },
 }
 
 impl ConfirmTarget {
     fn title(&self) -> String {
-        match self {
-            ConfirmTarget::Instance { name } => format!(" Delete '{}' ", name),
-            ConfirmTarget::ConfigProfile { profile } => format!(" Delete '{}' ", profile),
-        }
+        format!(" Delete '{}' ", self.name())
     }
 
     fn body(&self) -> &'static str {
@@ -42,13 +47,15 @@ impl ConfirmTarget {
             ConfirmTarget::ConfigProfile { .. } => {
                 "This will permanently remove this config profile"
             }
+            ConfirmTarget::Content { .. } => "This will permanently remove the selected item",
         }
     }
 
-    fn name(&self) -> &str {
+    pub fn name(&self) -> &str {
         match self {
             ConfirmTarget::Instance { name } => name,
             ConfirmTarget::ConfigProfile { profile } => profile,
+            ConfirmTarget::Content { name, .. } => name,
         }
     }
 }
@@ -66,6 +73,17 @@ pub fn set_pending(target: ConfirmTarget) {
 
 pub fn set_pending_delete(name: impl Into<String>) {
     set_pending(ConfirmTarget::Instance { name: name.into() });
+}
+
+pub fn set_pending_instance_delete(name: impl Into<String>) {
+    set_pending_delete(name);
+}
+
+pub fn set_pending_content_delete(name: impl Into<String>, path: impl Into<std::path::PathBuf>) {
+    set_pending(ConfirmTarget::Content {
+        name: name.into(),
+        path: path.into(),
+    });
 }
 
 pub fn pending_target() -> Option<ConfirmTarget> {

--- a/src/tui/widgets/popups/confirm.rs
+++ b/src/tui/widgets/popups/confirm.rs
@@ -27,6 +27,10 @@ pub enum ConfirmTarget {
     Instance {
         name: String,
     },
+    Account {
+        username: String,
+        index: usize,
+    },
     ConfigProfile {
         profile: String,
     },
@@ -44,6 +48,7 @@ impl ConfirmTarget {
     fn body(&self) -> &'static str {
         match self {
             ConfirmTarget::Instance { .. } => "This will permanently remove the instance",
+            ConfirmTarget::Account { .. } => "This will permanently remove this account",
             ConfirmTarget::ConfigProfile { .. } => {
                 "This will permanently remove this config profile"
             }
@@ -54,6 +59,7 @@ impl ConfirmTarget {
     pub fn name(&self) -> &str {
         match self {
             ConfirmTarget::Instance { name } => name,
+            ConfirmTarget::Account { username, .. } => username,
             ConfirmTarget::ConfigProfile { profile } => profile,
             ConfirmTarget::Content { name, .. } => name,
         }

--- a/src/tui/widgets/screenshots_grid.rs
+++ b/src/tui/widgets/screenshots_grid.rs
@@ -173,6 +173,30 @@ impl ScreenshotsState {
         }
         self.entries.len().div_ceil(self.cols)
     }
+
+    pub fn pending_delete(
+        &self,
+    ) -> Option<crate::tui::widgets::content::list::PendingContentDelete> {
+        let entry = self.entries.get(self.selected)?;
+        Some(crate::tui::widgets::content::list::PendingContentDelete {
+            name: entry.name.clone(),
+            path: entry.path.clone(),
+        })
+    }
+
+    pub fn remove_path(&mut self, path: &Path) {
+        self.entries.retain(|entry| entry.path != path);
+        self.protocols.clear();
+        self.requested.clear();
+
+        if self.entries.is_empty() {
+            self.selected = 0;
+            self.scroll_row = 0;
+        } else {
+            self.selected = self.selected.min(self.entries.len().saturating_sub(1));
+            self.ensure_visible();
+        }
+    }
 }
 
 pub fn handle_key(key_event: &KeyEvent, state: &mut ScreenshotsState) -> bool {


### PR DESCRIPTION
This adds a delete shortcut to the places where content can already be managed from the TUI. It reuses the existing confirmation flow so mods, resource packs, shaders, screenshots, worlds and logs can be removed without adding another popup implementation.